### PR TITLE
Display percentage of general fund used for policing

### DIFF
--- a/app/controllers/admin/police_districts_controller.rb
+++ b/app/controllers/admin/police_districts_controller.rb
@@ -46,8 +46,10 @@ class Admin::PoliceDistrictsController < Admin::ApplicationController
   def district_params
     params.require(:police_district).permit(
       :name,
-      :fy_2019_policing_budget,
-      :general_fund_percent,
+      :total_district_budget,
+      :total_police_department_budget,
+      :total_general_fund_budget,
+      :total_police_paid_from_general_fund_budget,
       :timezone,
       :decision_makers,
       :decision_makers_text,

--- a/app/models/police_district.rb
+++ b/app/models/police_district.rb
@@ -15,13 +15,19 @@ class PoliceDistrict < ApplicationRecord
   include ActionView::Helpers::NumberHelper
 
   def readable_budget
-    return '---' if fy_2019_policing_budget.nil?
+    return '---' if total_police_department_budget.nil?
 
-    number_to_human(fy_2019_policing_budget,format:'%n%u',precision: 4, units:{thousand:'K',million:'M',billion:'B'})
+    number_to_human(total_police_department_budget,format:'%n%u',precision: 4, units:{thousand:'K',million:'M',billion:'B'})
   end
 
   def next_meeting
     @next_meeting ||= meetings.where('event_datetime > ?', Time.zone.now - 8.hours).order('event_datetime').limit(1).first
+  end
+
+  def general_fund_spent_on_police_percentage
+    return unless total_general_fund_budget && total_police_paid_from_general_fund_budget
+
+    ((total_police_paid_from_general_fund_budget.to_f / total_general_fund_budget.to_f) * 100).round
   end
 
   def more_funding_than

--- a/app/views/admin/police_districts/_district_form.html.erb
+++ b/app/views/admin/police_districts/_district_form.html.erb
@@ -14,18 +14,23 @@
       </div>
 
       <div class="form-group form-group--medium">
-        <%= f.label :fy_2019_policing_budget, 'FY2019 Budget' %>
-        <%= f.number_field :fy_2019_policing_budget, class: 'form-control' %>
+        <%= f.label :total_police_department_budget, 'Total Police FY2019 Budget' %>
+        <%= f.number_field :total_police_department_budget, class: 'form-control' %>
       </div>
 
       <div class="form-group form-group--medium">
-        <%= f.label :total_city_budget, 'Total City Budget' %>
-        <%= f.number_field :total_city_budget, class: 'form-control' %>
+        <%= f.label :total_district_budget, 'Total FY2019 City Budget' %>
+        <%= f.number_field :total_district_budget, class: 'form-control' %>
       </div>
 
       <div class="form-group form-group--medium">
-        <%= f.label :general_fund_percent, 'General Fund Percent' %>
-        <%= f.number_field :general_fund_percent, class: 'form-control' %>
+        <%= f.label :total_general_fund_budget, 'Total FY2019 General Fund Budget' %>
+        <%= f.number_field :total_general_fund_budget, class: 'form-control' %>
+      </div>
+
+      <div class="form-group form-group--medium">
+        <%= f.label :total_police_paid_from_general_fund_budget, 'Total FY2019 General Fund Spent on Police' %>
+        <%= f.number_field :total_police_paid_from_general_fund_budget, class: 'form-control' %>
       </div>
 
       <div class="form-group">

--- a/app/views/police_districts/show.html.erb
+++ b/app/views/police_districts/show.html.erb
@@ -20,6 +20,26 @@
         <p><%= @district.next_meeting.agenda_details %></p>
       </div>
     <% end %>
+    <% if @district.general_fund_spent_on_police_percentage %>
+      <div class="section" data-spec="general-fund">
+        <h2 class="h4">General Fund</h2>
+        <div>
+          <div>
+            <!--TODO: pie chart-->
+          </div>
+          <div>
+            <p>
+              <span class="h3"><%= @district.general_fund_spent_on_police_percentage %>%</span>
+              of <%= @district.name %>'s <strong>2019 General Fund</strong>
+              was spent on law enforcement.
+            </p>
+            <p>
+              A general fund is money that the city can decide how to spend, and comes from a city's revenue, like taxes.
+            </p>
+          </div>
+        </div>
+      </div>
+    <% end %>
     <% if @district.more_funding_than.present? %>
       <div class="section">
         <h2 class="h4">Law enforcement gets more funding than:</h2>

--- a/db/migrate/20200620035929_split_out_general_fund_stats.rb
+++ b/db/migrate/20200620035929_split_out_general_fund_stats.rb
@@ -1,0 +1,11 @@
+class SplitOutGeneralFundStats < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :police_districts, :fy_2019_policing_budget, :total_police_department_budget
+    rename_column :police_districts, :total_city_budget, :total_district_budget
+
+    add_column :police_districts, :total_general_fund_budget, :integer
+    add_column :police_districts, :total_police_paid_from_general_fund_budget, :integer
+
+    remove_column :police_districts, :general_fund_percent
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_19_194347) do
+ActiveRecord::Schema.define(version: 2020_06_20_035929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,13 +41,12 @@ ActiveRecord::Schema.define(version: 2020_06_19_194347) do
   create_table "police_districts", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug", null: false
-    t.integer "fy_2019_policing_budget"
+    t.integer "total_police_department_budget"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "decision_makers"
     t.string "timezone"
-    t.bigint "total_city_budget"
-    t.integer "general_fund_percent"
+    t.bigint "total_district_budget"
     t.text "decision_makers_text"
     t.string "law_enforcement_gets_more_than_1"
     t.bigint "law_enforcement_gets_more_than_1_dollars"
@@ -55,6 +54,8 @@ ActiveRecord::Schema.define(version: 2020_06_19_194347) do
     t.bigint "law_enforcement_gets_more_than_2_dollars"
     t.string "law_enforcement_gets_more_than_3"
     t.bigint "law_enforcement_gets_more_than_3_dollars"
+    t.integer "total_general_fund_budget"
+    t.integer "total_police_paid_from_general_fund_budget"
     t.index ["slug"], name: "index_police_districts_on_slug", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ def create_district(name, slug)
   )
   district.update(
     name: name,
-    fy_2019_policing_budget: rand(900_000..1_200_000_000),
+    total_police_department_budget: rand(900_000..1_200_000_000),
     timezone: 'Pacific Time (US & Canada)'
   )
   meeting = Meeting.create(

--- a/spec/models/police_district_spec.rb
+++ b/spec/models/police_district_spec.rb
@@ -69,24 +69,24 @@ RSpec.describe PoliceDistrict, type: :model do
   describe '#readable_budget' do
     context 'when present' do
       it 'returns amount in billions' do
-        district = FactoryBot.create(:police_district, fy_2019_policing_budget: 1_900_600_000)
+        district = FactoryBot.create(:police_district, total_police_department_budget: 1_900_600_000)
         expect(district.readable_budget).to eq('1.901B')
       end
 
       it 'returns amount in millions, rounded to nearest' do
-        district = FactoryBot.create(:police_district, fy_2019_policing_budget: 190_590_000)
+        district = FactoryBot.create(:police_district, total_police_department_budget: 190_590_000)
         expect(district.readable_budget).to eq('190.6M')
       end
 
       it 'handles amounts under 1 mil' do
-        district = FactoryBot.create(:police_district, fy_2019_policing_budget: 600_000)
+        district = FactoryBot.create(:police_district, total_police_department_budget: 600_000)
         expect(district.readable_budget).to eq('600K')
       end
     end
 
     context 'when not present' do
       it 'returns "---"' do
-        district = FactoryBot.create(:police_district, fy_2019_policing_budget: nil)
+        district = FactoryBot.create(:police_district, total_police_department_budget: nil)
         expect(district.readable_budget).to eq('---')
       end
     end
@@ -127,6 +127,38 @@ RSpec.describe PoliceDistrict, type: :model do
         travel_to Time.zone.now + 12.hours do
           expect(PoliceDistrict.find(district.id).next_meeting).to be_nil
         end
+      end
+    end
+  end
+
+  describe '#general_fund_spent_on_police_percentage' do
+    context 'when both total_general_fund_budget and total_police_paid_from_general_fund_budget are present' do
+      it 'calculates the percentage, rounded to neareset 1%' do
+        district = FactoryBot.build(:police_district,
+                                    total_general_fund_budget: 1000,
+                                    total_police_paid_from_general_fund_budget: 165)
+
+        expect(district.general_fund_spent_on_police_percentage).to eq(17)
+      end
+    end
+
+    context 'when total_general_fund_budget is nil' do
+      it 'returns nil' do
+        district = FactoryBot.build(:police_district,
+                                    total_general_fund_budget: nil,
+                                    total_police_paid_from_general_fund_budget: 10_000)
+
+        expect(district.general_fund_spent_on_police_percentage).to be_nil
+      end
+    end
+
+    context 'when total_police_paid_from_general_fund_budget is nil' do
+      it 'returns nil' do
+        district = FactoryBot.build(:police_district,
+                                    total_general_fund_budget: 10_000,
+                                    total_police_paid_from_general_fund_budget: nil)
+
+        expect(district.general_fund_spent_on_police_percentage).to be_nil
       end
     end
   end

--- a/spec/system/admin/adds_information_spec.rb
+++ b/spec/system/admin/adds_information_spec.rb
@@ -15,11 +15,12 @@ RSpec.describe 'information management' do
     click_on 'Add a new district'
 
     fill_in 'Name', with: 'BART PD'
-    fill_in 'FY2019 Budget', with: '160,000,000'
-    fill_in 'Total City Budget', with: '1,000,000,000'
-    fill_in 'General Fund Percent', with: '65'
+    fill_in 'Total Police FY2019 Budget', with: '160,000,000'
+    fill_in 'Total FY2019 City Budget', with: '1,000,000,000'
+    fill_in 'Total FY2019 General Fund Budget', with: '50,000,000'
+    fill_in 'Total FY2019 General Fund Spent on Police', with: '25,000,000'
     fill_in 'Decision makers', with: 'Cardamom Pod, Cumin Seed'
-    fill_in 'Decision makers text', with: "The following people are decision makers."
+    fill_in 'Decision makers text', with: 'The following people are decision makers.'
 
     fill_in 'police_district_law_enforcement_gets_more_than_1', with: 'Transit'
     fill_in 'police_district_law_enforcement_gets_more_than_1_dollars', with: '1000000'
@@ -41,6 +42,10 @@ RSpec.describe 'information management' do
 
     expect(page).to have_content('Transit')
     expect(page).to have_content('1000000')
+
+    within '[data-spec=general-fund]' do
+      expect(page).to have_text "50% of BART PD's 2019 General Fund was spent on law enforcement"
+    end
 
     visit '/admin/police_districts/bart-pd'
     expect(page).to have_text('Pacific Time (US & Canada)')

--- a/spec/system/views_information_spec.rb
+++ b/spec/system/views_information_spec.rb
@@ -5,11 +5,16 @@ RSpec.describe 'information viewing' do
     district = FactoryBot.create(:police_district,
                                  name: 'Down town',
                                  slug: 'down-town',
-                                 fy_2019_policing_budget: 950_000_000,
+                                 total_police_department_budget: 950_000_000,
                                  timezone: 'Pacific Time (US & Canada)')
 
-    FactoryBot.create(:meeting, police_district: district, event_datetime: DateTime.new(2025,6,20,5,30,00, '-7'))
-    FactoryBot.create(:meeting, police_district: district, event_datetime: DateTime.new(2022,6,30,11,30,00, '-7'))
+    FactoryBot.create(:meeting,
+                      police_district: district,
+                      event_datetime: DateTime.new(2025,6,20,5,30,00, '-7'))
+
+    FactoryBot.create(:meeting,
+                      police_district: district,
+                      event_datetime: DateTime.new(2022,6,30,11,30,00, '-7'))
   end
 
   it 'shows index of all jurisdictions' do


### PR DESCRIPTION
- Renames database fields related to budget to make a little more
consistent
- Allows user to enter dollar amounts for general fund and the amount of
general fund that went toward policing
- Calculates percentage of general fund used for policing, and puts on
the page

Makes progress on #28, but still needs a pie chart