### PR TITLE
Add geocoding to police districts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'puma', '~> 3.11'
 gem 'jbuilder', '~> 2.5'
 gem 'devise'
 gem 'webpacker'
+gem 'geocoder'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     factory_bot_rails (5.2.0)
       factory_bot (~> 5.2.0)
       railties (>= 4.2.0)
+    geocoder (1.6.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.3)
@@ -198,6 +199,7 @@ DEPENDENCIES
   capybara
   devise
   factory_bot_rails
+  geocoder
   jbuilder (~> 2.5)
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/app/controllers/admin/police_districts_controller.rb
+++ b/app/controllers/admin/police_districts_controller.rb
@@ -53,6 +53,7 @@ class Admin::PoliceDistrictsController < Admin::ApplicationController
       :total_general_fund_budget,
       :total_police_paid_from_general_fund_budget,
       :timezone,
+      :address,
       :decision_makers_text,
       :elected_officials_contact_link,
       :law_enforcement_gets_more_than_1,

--- a/app/controllers/police_districts_controller.rb
+++ b/app/controllers/police_districts_controller.rb
@@ -2,7 +2,7 @@ class PoliceDistrictsController < ApplicationController
   include GoogleCalendarable
 
   def index
-    @districts = PoliceDistrict.with_upcoming_meetings
+    @districts = (params[:near].present? ? PoliceDistrict.near(params[:near]) : PoliceDistrict.all).with_upcoming_meetings
   end
 
   def show

--- a/app/models/police_district.rb
+++ b/app/models/police_district.rb
@@ -12,7 +12,16 @@ class PoliceDistrict < ApplicationRecord
   has_many :meetings
   has_many :elected_officials
 
+  geocoded_by :address
+  after_validation :geocode, if: ->(obj){ obj.address.present? and obj.address_changed? }
   after_validation :set_slug
+  reverse_geocoded_by :latitude, :longitude do |obj,results|
+    if geo = results.first
+      obj.address = "#{geo.city}, #{geo.state}"
+    end
+  end
+
+  after_validation :reverse_geocode
 
   include ActionView::Helpers::NumberHelper
 

--- a/app/views/admin/police_districts/_district_form.html.erb
+++ b/app/views/admin/police_districts/_district_form.html.erb
@@ -8,6 +8,11 @@
       </div>
 
       <div class="form-group form-group--medium">
+        <%= f.label :address %>
+        <%= f.text_field :address, class: 'form-control' %>
+      </div>
+
+      <div class="form-group form-group--medium">
         <%= f.label :timezone %>
         <div>
           <%= f.select :timezone,

--- a/db/migrate/20200626061125_add_geocoding.rb
+++ b/db/migrate/20200626061125_add_geocoding.rb
@@ -1,0 +1,7 @@
+class AddGeocoding < ActiveRecord::Migration[5.2]
+  def change
+    add_column :police_districts, :latitude, :float, null: true
+    add_column :police_districts, :longitude, :float, null: true
+    add_column :police_districts, :address, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_25_193812) do
+ActiveRecord::Schema.define(version: 2020_06_26_061125) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,9 @@ ActiveRecord::Schema.define(version: 2020_06_25_193812) do
     t.bigint "total_general_fund_budget"
     t.bigint "total_police_paid_from_general_fund_budget"
     t.string "elected_officials_contact_link"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "address"
     t.index ["slug"], name: "index_police_districts_on_slug", unique: true
   end
 


### PR DESCRIPTION
This PR adds geocoding fields, such that:

Admin forms allow people to put in a location field, which is then translated into a set of lat/longs.
Addresses are reverse geocoded so that they're cleaned up and easy to read. For example: "seattle, wa" becomes "Seattle, Washington".

The main page, if given a "near" query parameter, will show only districts within 50 miles of that location. For example:
`/?near=%22san%20francisco%22` will show districts near SF.

