### PR TITLE
Add optional 'about' text field for meeting

### DIFF
--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -53,7 +53,8 @@ class Admin::MeetingsController < Admin::ApplicationController
       :event_datetime,
       :agenda_link,
       :agenda_details,
-      :how_to_comment
+      :how_to_comment,
+      :about
     )
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   respond_to :html
 
   helper_method :body_classes
+  helper ApplicationHelper
 
   def body_classes
     [controller_name, action_name]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+  def convert_newlines_to_paragraphs(text)
+    return unless text.present?
+
+    text.split("\n").map{|paragraph| "<p>#{paragraph}</p>"}.join('').html_safe
+  end
 end

--- a/app/views/admin/meetings/_meeting_form.html.erb
+++ b/app/views/admin/meetings/_meeting_form.html.erb
@@ -23,6 +23,10 @@
       <%= f.label :how_to_comment, 'How to comment' %>
       <%= f.text_area :how_to_comment, class: 'form-control' %>
     </div>
+    <div class="form-group">
+      <%= f.label :about, 'About this meeting' %>
+      <%= f.text_area :about, class: 'form-control' %>
+    </div>
     <%= f.submit %>
   <% end %>
 </div>

--- a/app/views/police_districts/show.html.erb
+++ b/app/views/police_districts/show.html.erb
@@ -6,6 +6,15 @@
   <%= render partial: 'shared/district_header', locals: { district: @district } %>
 
   <div class="district-info">
+    <% if @district.next_meeting&.about.present? %>
+      <div class="section">
+        <h2 class="h4">About this meeting</h2>
+        <div class="about">
+          <%= convert_newlines_to_paragraphs(@district.next_meeting&.about) %>
+        </div>
+      </div>
+    <% end %>
+
     <div class="section">
       <h2 class="h4">How to comment</h2>
       <% (@district.next_meeting&.how_to_comment || '').split("\n").each_with_index do |step, i| %>
@@ -99,7 +108,9 @@
     <% end %>
     <div class="section">
       <h2 class="h4">Decision Makers</h2>
-      <div class="decision-makers-text"><%= @district.decision_makers_text %></div>
+      <div class="decision-makers-text">
+        <%= convert_newlines_to_paragraphs(@district.decision_makers_text) %>
+      </div>
       <div class="row columned-list">
         <% @district.elected_officials.each_with_index do |elected_official, i| %>
           <div class="columned-item col-sm">

--- a/db/migrate/20200625193812_add_about_this_meeting_to_meeting.rb
+++ b/db/migrate/20200625193812_add_about_this_meeting_to_meeting.rb
@@ -1,0 +1,5 @@
+class AddAboutThisMeetingToMeeting < ActiveRecord::Migration[5.2]
+  def change
+    add_column :meetings, :about, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_22_040428) do
+ActiveRecord::Schema.define(version: 2020_06_25_193812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2020_06_22_040428) do
     t.text "agenda_details"
     t.text "how_to_comment"
     t.string "video_link"
+    t.text "about"
     t.index ["police_district_id"], name: "index_meetings_on_police_district_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,7 +16,7 @@ def create_district(name, slug)
     timezone: 'Pacific Time (US & Canada)',
     total_general_fund_budget: 1_000_000_000,
     total_police_paid_from_general_fund_budget: 420_000_000,
-    decision_makers_text: "A budget proposal is made by the mayor, advised by the Budget Advisory Committee.",
+    decision_makers_text: "A budget proposal is made by the mayor, advised by the Budget Advisory Committee.\nSee below for elected offficals.",
     elected_officials_contact_link: "www.google.com"
   )
   Meeting.create!(
@@ -25,7 +25,8 @@ def create_district(name, slug)
     video_link: "http://example.com/meeting",
     how_to_comment: "Call 1-800-555-5555 to join the meeting.\nPress * 9 to raise your hand to speak.\nWait until you are unmuted and begin speaking.\n",
     agenda_link: "www.google.com",
-    agenda_details: "Zero Tolerance Policy For Racist Practices, OPD Spotshotter Contract"
+    agenda_details: "Zero Tolerance Policy For Racist Practices, OPD Spotshotter Contract",
+    about: "This meeting is very important.\nBe sure to call in."
   )
 
   create_official(district, 1, "Sandra Lee Fewer", "District 1", "Nov. 2022")

--- a/spec/controllers/admin/meetings_controller_spec.rb
+++ b/spec/controllers/admin/meetings_controller_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Admin::MeetingsController, type: :controller do
             'event_datetime(3i)' => '14',
             'event_datetime(4i)' => '4',
             'event_datetime(5i)' => '0',
-            agenda_link: 'asfd'
+            agenda_link: 'asfd',
+            about: 'what the meeting is about'
           },
           police_district_id: district.slug
         }
@@ -32,6 +33,15 @@ RSpec.describe Admin::MeetingsController, type: :controller do
         end
         meeting = Meeting.last
         expect(meeting.event_datetime).to eq(DateTime.new(2020,6,14,11,0,0,'0'))
+      end
+
+      it 'sets the attributes' do
+        travel_to Date.parse('2020-6-13') do
+          post :create, params: valid_params
+        end
+
+        meeting = Meeting.last
+        expect(meeting.about).to eq('what the meeting is about')
       end
     end
 

--- a/spec/system/admin/adds_information_spec.rb
+++ b/spec/system/admin/adds_information_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe 'information management' do
       fill_in 'Agenda Details', with: 'First, transporation budget, then police budget'
 
       fill_in 'How to comment', with: "Do this.\nDo that.\n"
+      fill_in 'About this meeting', with: "It's a special meeting.\nReally.\n"
 
       click_on 'Create Meeting'
 
@@ -109,6 +110,8 @@ RSpec.describe 'information management' do
 
       expect(page).to have_content('Do this.')
       expect(page).to have_content('Do that.')
+      expect(page).to have_content("It's a special meeting.")
+      expect(page).to have_content("Really.")
       expect(page).to have_link("Review this meeting's agenda")
       expect(page).to have_link('Watch this meeting online')
       expect(page).to have_content('First, transporation budget, then police budget')


### PR DESCRIPTION
Also creates a "convert_newlines_to_paragraphs" helper to be used in
views that will create paragraphs (`<p></p>`) based on newlines in the
saved text.

[Finishes #71]