### PR TITLE
Don't require "how to comment" when showing meeting

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,7 +1,16 @@
 class Meeting < ApplicationRecord
   include LinkPrefixHelper
 
+  MEETING_WAIT_PERIOD = 8.hours
+
   belongs_to :police_district
+
+  scope :upcoming_and_ongoing, -> {
+    where('event_datetime > ?', Time.current.utc - MEETING_WAIT_PERIOD).order(event_datetime: :asc)
+  }
+  scope :past, -> {
+    where('event_datetime <= ?', Time.current.utc - MEETING_WAIT_PERIOD).order(event_datetime: :desc)
+  }
 
   def formatted_event_datetime
     event_datetime&.in_time_zone(police_district.timezone)&.strftime('%A, %B %e at %l:%M%P')

--- a/app/models/police_district.rb
+++ b/app/models/police_district.rb
@@ -32,7 +32,6 @@ class PoliceDistrict < ApplicationRecord
   def next_meeting
     @next_meeting ||= meetings
       .where('event_datetime > ?', Time.current.utc - 8.hours)
-      .where.not(how_to_comment: [nil, ""])
       .order('event_datetime')
       .limit(1)
       .first

--- a/app/views/police_districts/index.html.erb
+++ b/app/views/police_districts/index.html.erb
@@ -8,19 +8,23 @@
       </div>
   </div>
   <div class="district-list">
-    <h1 class="h2">Upcoming meetings</h1>
-    <div class="district-list-subtitle">
-      Want to help us add a city or police district that isn't here?
-      <%= mail_to ENV.fetch('CONTACT_EMAIL', 'contact@example.com'), 'Get in touch.', class: 'link-yellow' %>
-    </div>
-    <% @districts_with_future_meetings.each do |district| %>
-      <%= render partial: 'shared/district_card', locals: { district: district, district_path: police_district_path(district) } %>
-    <% end %>
-    <% if @districts_with_past_meetings.present? %>
-      <h1 class="h2 recent-meetings">Recent meetings</h1>
-      <% @districts_with_past_meetings.each do |district| %>
-        <%= render partial: 'shared/district_card', locals: { district: district, district_path: police_district_path(district) } %>
+    <div data-spec="upcoming-meetings">
+      <h1 class="h2">Upcoming meetings</h1>
+      <div class="district-list-subtitle">
+        Want to help us add a city or police district that isn't here?
+        <%= mail_to ENV.fetch('CONTACT_EMAIL', 'contact@example.com'), 'Get in touch.', class: 'link-yellow' %>
+      </div>
+      <% @districts_with_future_meetings.each do |district| %>
+          <%= render partial: 'shared/district_card', locals: { district: district, district_path: police_district_path(district) } %>
       <% end %>
+    </div>
+    <% if @districts_with_past_meetings.present? %>
+      <div class="recent-meetings" data-spec="recent-meetings">
+        <h1 class="h2">Recent meetings</h1>
+        <% @districts_with_past_meetings.each do |district| %>
+          <%= render partial: 'shared/district_card', locals: { district: district, district_path: police_district_path(district) } %>
+        <% end %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/police_districts/show.html.erb
+++ b/app/views/police_districts/show.html.erb
@@ -29,7 +29,7 @@
           <% end %>
         <% else %>
           <div class="how-to-comment">
-            We'll have more information on this soon. Check back within 72 hours of the meeting.
+            We'll have information on this closer to the meeting date. Check back soon.
           </div>
         <% end %>
       </div>

--- a/app/views/police_districts/show.html.erb
+++ b/app/views/police_districts/show.html.erb
@@ -15,36 +15,47 @@
       </div>
     <% end %>
 
-    <div class="section">
-      <h2 class="h4">How to comment</h2>
-      <% (@district.next_meeting&.how_to_comment || '').split("\n").each_with_index do |step, i| %>
-        <div class="how-to-comment">
-          <div class="how-to-comment-number">
-            <div><%= "#{i + 1}" %></div>
+    <% if next_meeting = @district.next_meeting %>
+      <div class="section">
+        <h2 class="h4">How to comment</h2>
+        <% if @district.next_meeting.how_to_comment.present? %>
+          <% @district.next_meeting.how_to_comment.split("\n").each_with_index do |step, i| %>
+            <div class="how-to-comment">
+              <div class="how-to-comment-number">
+                <div><%= "#{i + 1}" %></div>
+              </div>
+              <div><%= "#{step}" %></div>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="how-to-comment">
+            We'll have more information on this soon. Check back within 72 hours of the meeting.
           </div>
-          <div><%= "#{step}" %></div>
+        <% end %>
+      </div>
+
+      <% if next_meeting.agenda_link.present? %>
+        <div class="section">
+          <h2 class="h4">Agenda</h2>
+          <div class="row-link">
+            <div class="link-icon agenda"></div>
+            <div><%= link_to "Review this meeting's agenda", next_meeting.agenda_link_prefixed, target: :_blank %></div>
+          </div>
+          <div class="agenda-details">Items related to law enforcement on this agenda: <span class="agenda-items"><%= "#{next_meeting.agenda_details}" %></span></div>
         </div>
       <% end %>
-    </div>
-    <% if @district.next_meeting&.agenda_link.present? %>
-      <div class="section">
-        <h2 class="h4">Agenda</h2>
-        <div class="row-link">
-          <div class="link-icon agenda"></div>
-          <div><%= link_to "Review this meeting's agenda", @district.next_meeting.agenda_link_prefixed, target: :_blank %></div>
+
+      <% if next_meeting.video_link.present? %>
+        <div class="section">
+          <h2 class="h4">Watch</h2>
+          <div class="row-link">
+            <div class="link-icon watch"></div>
+            <div><%= link_to "Watch this meeting online", next_meeting.video_link_prefixed, target: :_blank %></div>
+          </div>
         </div>
-        <div class="agenda-details">Items related to law enforcement on this agenda: <span class="agenda-items"><%= "#{@district.next_meeting.agenda_details}" %></span></div>
-      </div>
+      <% end %>
     <% end %>
-    <% if @district.next_meeting&.video_link.present? %>
-      <div class="section">
-        <h2 class="h4">Watch</h2>
-        <div class="row-link">
-          <div class="link-icon watch"></div>
-          <div><%= link_to "Watch this meeting online", @district.next_meeting.video_link_prefixed, target: :_blank %></div>
-        </div>
-      </div>
-    <% end %>
+
     <% if @district.general_fund_spent_on_police_percentage %>
       <div class="section" data-spec="general-fund">
         <h2 class="h4">General Fund</h2>
@@ -74,7 +85,8 @@
         </div>
       </div>
     <% end %>
-    <% if @district.more_funding_than.present? and @district.more_funding_than.length() > 1 %>
+
+    <% if @district.more_funding_than.present? and @district.more_funding_than.length > 1 %>
       <div class="section">
         <h2 class="h4">In comparison</h2>
         <p>Here are some examples of 2019 budget items that received less funding than law enforcement:</p>
@@ -106,6 +118,7 @@
         </div>
       </div>
     <% end %>
+
     <div class="section">
       <h2 class="h4">Decision Makers</h2>
       <div class="decision-makers-text">

--- a/app/views/shared/_district_card.html.erb
+++ b/app/views/shared/_district_card.html.erb
@@ -1,5 +1,5 @@
 <%= link_to district_path do %>
-  <div id="district-<%= district.slug %>" class="district-card">
+  <div class="district-card">
     <div class="district-card-details-primary">
       <h2 class="h4"><%= district.name %></h2>
       <div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-def create_district(name, slug, with_meeting: true, has_future_meeting: false, meeting_attrs: {})
+def create_district(name, slug, with_meeting: true, has_future_meeting: true, meeting_attrs: {})
   district = PoliceDistrict.find_or_initialize_by(
     slug: slug,
   )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-def create_district(name, slug, has_future_meeting)
+def create_district(name, slug, with_meeting: true, has_future_meeting: false, meeting_attrs: {})
   district = PoliceDistrict.find_or_initialize_by(
     slug: slug,
   )
@@ -19,25 +19,39 @@ def create_district(name, slug, has_future_meeting)
     decision_makers_text: "A budget proposal is made by the mayor, advised by the Budget Advisory Committee.\nSee below for elected offficals.",
     elected_officials_contact_link: "www.google.com"
   )
+  puts "District #{district.name}: Created or updated district with slug '#{district.slug}'"
+  if with_meeting
+    create_meeting(district, in_future: has_future_meeting, attr_overrides: meeting_attrs)
+  end
 
-  meeting_date = has_future_meeting ? (Date.today + rand(2..30).days) : Date.yesterday
-  Meeting.create!(
+  if district.elected_officials.none?
+    officials = []
+    officials << create_official(district, 1, "Sandra Lee Fewer", "District 1", "Nov. 2022")
+    officials << create_official(district, 2, "Catherine Stefani", "District 2", "Nov. 2022")
+    officials << create_official(district, 3, "Aaron Peskin", "District 3", "Nov. 2022")
+    officials << create_official(district, 4, "Gordon Mar", "District 4", "Nov. 2022")
+    officials << create_official(district, 5, "Dean Preston", "District 5", "Nov. 2022")
+    puts "District #{district.name}: Created elected officials #{officials.map(&:name)}"
+  end
+
+  puts "\n"
+  district
+end
+
+def create_meeting(district, attr_overrides: {}, in_future: true)
+  attributes = {
     police_district: district,
-    event_datetime: meeting_date,
+    event_datetime: in_future ? Date.today + rand(2..30).days : Date.today - rand(2..30).days,
     video_link: "http://example.com/meeting",
     how_to_comment: "Call 1-800-555-5555 to join the meeting.\nPress * 9 to raise your hand to speak.\nWait until you are unmuted and begin speaking.\n",
     agenda_link: "www.google.com",
     agenda_details: "Zero Tolerance Policy For Racist Practices, OPD Spotshotter Contract",
-    about: "This meeting is very important.\nBe sure to call in."
-  )
+    about: "This meeting is very important.\nBe sure to call in.",
+  }.merge(attr_overrides)
 
-  create_official(district, 1, "Sandra Lee Fewer", "District 1", "Nov. 2022")
-  create_official(district, 2, "Catherine Stefani", "District 2", "Nov. 2022")
-  create_official(district, 3, "Aaron Peskin", "District 3", "Nov. 2022")
-  create_official(district, 4, "Gordon Mar", "District 4", "Nov. 2022")
-  create_official(district, 5, "Dean Preston", "District 5", "Nov. 2022")
-
-  puts "Created or updated district with slug '#{district.slug}'"
+  meeting = Meeting.create!(attributes)
+  puts "District #{district.name}: Created meeting at #{meeting.event_datetime}"
+  meeting
 end
 
 def create_official(district, list_rank, name, position, reelection_date)
@@ -50,10 +64,12 @@ def create_official(district, list_rank, name, position, reelection_date)
   )
 end
 
-create_district("San Francisco", "san-francisco", true)
-create_district("Oakland", "oakland", true)
-create_district("Los Angeles", "los-angeles", true)
-create_district("BART", "bart", false)
+create_district("San Francisco", "san-francisco")
+create_district("Oakland", "oakland")
+create_district("Los Angeles", "los-angeles")
+create_district("BART", "bart", has_future_meeting: false)
+create_district("San Mateo", "san-mateo", with_meeting: false)
+create_district("Richmond", "richmond", meeting_attrs: { how_to_comment: nil })
 
 user = User.find_or_initialize_by(
   email: ENV.fetch('SEED_USER_EMAIL', 'admin@example.com')

--- a/spec/models/police_district_spec.rb
+++ b/spec/models/police_district_spec.rb
@@ -107,14 +107,6 @@ RSpec.describe PoliceDistrict, type: :model do
       end
     end
 
-    context 'where there are future meetings without required info' do
-      it 'returns nil' do
-        soon_meeting = FactoryBot.create(:meeting, police_district: district, how_to_comment: '', event_datetime: Date.today + 5.days)
-
-        expect(district.next_meeting).to be_nil
-      end
-    end
-
     context 'where there is a meeting in progress' do
       it 'returns the in progress meeting' do
         in_progress_meeting = FactoryBot.create(:meeting, police_district: district, event_datetime: Time.zone.now + 1.minute)

--- a/spec/system/views_information_spec.rb
+++ b/spec/system/views_information_spec.rb
@@ -2,21 +2,26 @@ require 'rails_helper'
 
 RSpec.describe 'information viewing' do
   before do
-    district = FactoryBot.create(:police_district,
+    district_one = FactoryBot.create(:police_district,
                                  name: 'Down town',
                                  slug: 'down-town',
                                  total_police_department_budget: 950_000_000,
                                  decision_makers_text: 'Some people decide on these things',
                                  timezone: 'Pacific Time (US & Canada)')
 
+    district_two = FactoryBot.create(:police_district,
+                                 name: 'Stu Ville',
+                                 slug: 'stu-ville',
+                                 total_police_department_budget: 10_000_000,
+                                 timezone: 'Pacific Time (US & Canada)')
+
     FactoryBot.create(:meeting,
-                      police_district: district,
+                      police_district: district_one,
                       event_datetime: DateTime.new(2025,6,20,5,30,00, '-7'))
 
     FactoryBot.create(:meeting,
-                      police_district: district,
-                      how_to_comment: 'Call in and talk',
-                      event_datetime: DateTime.new(2022,6,30,11,30,00, '-7'))
+                      police_district: district_two,
+                      event_datetime: DateTime.new(2010,6,30,11,30,00, '-7'))
   end
 
   it 'shows index of districts, and allows visiting district info page' do
@@ -24,19 +29,24 @@ RSpec.describe 'information viewing' do
 
     expect(page).to have_content('Reinvest in us.')
 
-    within '#district-down-town' do
+    within '[data-spec=upcoming-meetings]' do
       expect(page).to have_content('Down town')
       expect(page).to have_content('$950M')
-      expect(page).to have_content('Thursday, June 30 at 11:30am')
+      expect(page).to have_content('Friday, June 20 at 5:30am')
+    end
+
+    within '[data-spec=recent-meetings]' do
+      expect(page).to have_content('Stu Ville')
+      expect(page).to have_content('$10M')
+      expect(page).to have_content('Wednesday, June 30 at 11:30am')
     end
 
     click_on 'Down town'
 
     expect(page).to have_content('Down town')
     expect(page).to have_content('$950M')
-    expect(page).to have_content('Thursday, June 30 at 11:30am')
+    expect(page).to have_content('Friday, June 20 at 5:30am')
     expect(page).to have_content('Some people decide on these things')
-    expect(page).to have_content('Call in and talk')
     expect(page).to have_link('Add to calendar')
   end
 


### PR DESCRIPTION
Sometimes we may have meetings that are scheduled but don't yet have
steps to comment since the agenda hasn't been posted.

Previously, we did not include these meetings on the home page (filtered
to make sure 'how to comment' was present). Also, if you visited the
district page, you would still see "How to comment" even though the
meeting has passed.

This PR modifies next_meeting so that it shows any scheduled upcoming
meetings, even without comment info. It then shows placeholder text
("Check back within 72 hours") if the comment info isn't provided.

Lastly, if there is no upcoming meeting then the 'How to comment' info
is hidden entirely on the district page.

[Note: will need to be updated once #74 is merged, so submitting as a draft]

Examples of what it looks like (ignore that graph isn't showing, that's just my dev env):

## With no upcoming meeting (e.g. if there are only meetings in the past)
<img width="940" alt="Screen Shot 2020-06-26 at 8 24 03 AM" src="https://user-images.githubusercontent.com/3675092/85879551-720ecb80-b78f-11ea-992e-4c4ad1defdc1.png">

## With scheduled upcoming meetings

**When no how to comment is set** (shows up on index)
<img width="923" alt="Screen Shot 2020-06-26 at 8 27 13 AM" src="https://user-images.githubusercontent.com/3675092/85879543-6d4a1780-b78f-11ea-9712-fafc69e508a1.png">

(placeholder text for how_to_comment)
<img width="1195" alt="Screen Shot 2020-06-26 at 2 00 34 PM" src="https://user-images.githubusercontent.com/3675092/85900891-71892b80-b7b5-11ea-8c79-bfdebc4afde9.png">