### PR TITLE
Adds support for non-Pacific timezones

### DIFF
--- a/app/controllers/concerns/timezonable.rb
+++ b/app/controllers/concerns/timezonable.rb
@@ -16,4 +16,12 @@ module Timezonable
   def convert_and_strip_timezone(datetime, timezone)
     datetime.in_time_zone(timezone).to_datetime.change(offset: 0)
   end
+
+  def self.default_zone
+    'Pacific Time (US & Canada)'
+  end
+
+  def self.us_zone_names
+    TimeZone.us_zones.map{|z| z.name }
+  end
 end

--- a/app/models/google_calendar.rb
+++ b/app/models/google_calendar.rb
@@ -7,12 +7,6 @@ class GoogleCalendar
 
   BASE_URL = 'https://www.google.com/calendar/render'
 
-  # A map of Rails timezone strings we support to Python, which Google
-  #   Calendar supports
-  TIMEZONE_LOOKUP = {
-    'Pacific Time (US & Canada)' => 'US/Pacific',
-  }.freeze
-
   def initialize(context)
     @context = context # needs controller context for route helper
   end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -13,7 +13,7 @@ class Meeting < ApplicationRecord
   }
 
   def formatted_event_datetime
-    event_datetime&.in_time_zone(police_district.timezone)&.strftime('%A, %B %e at %l:%M%P')
+    event_datetime&.in_time_zone(police_district.timezone)&.strftime('%A, %B %e at %l:%M%P %Z')
   end
 
   def agenda_link_prefixed

--- a/app/models/police_district.rb
+++ b/app/models/police_district.rb
@@ -1,9 +1,9 @@
 class PoliceDistrict < ApplicationRecord
+  include Timezonable
   include LinkPrefixHelper
 
-  TIME_ZONE_OPTIONS = [
-    'Pacific Time (US & Canada)'
-  ].freeze # supported valid timezones (from rake:time:zones[US] )
+  TIME_ZONE_DEFAULT = Timezonable.default_zone.freeze
+  TIME_ZONE_OPTIONS = Timezonable.us_zone_names.freeze
 
   validates_presence_of :name, :total_police_department_budget
   validates :slug, uniqueness: true, format: { with: /\A[a-z0-9\-]+\Z/ }, allow_blank: true

--- a/app/views/admin/police_districts/_district_form.html.erb
+++ b/app/views/admin/police_districts/_district_form.html.erb
@@ -16,7 +16,7 @@
         <%= f.label :timezone %>
         <div>
           <%= f.select :timezone,
-                       options_for_select(PoliceDistrict::TIME_ZONE_OPTIONS, (@district.timezone || PoliceDistrict::TIME_ZONE_OPTIONS.first)) %>
+                       options_for_select(PoliceDistrict::TIME_ZONE_OPTIONS, (@district.timezone || PoliceDistrict::TIME_ZONE_DEFAULT)) %>
         </div>
       </div>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,11 +6,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-def create_district(name, slug, with_meeting: true, has_future_meeting: true, meeting_attrs: {})
-  district = PoliceDistrict.find_or_initialize_by(
-    slug: slug,
-  )
-  district.update!(
+def create_district(name, slug, with_meeting: true, has_future_meeting: true, district_attrs: {}, meeting_attrs: {})
+  district_attributes = {
     name: name,
     total_police_department_budget: rand(900_000..1_200_000_000),
     timezone: 'Pacific Time (US & Canada)',
@@ -18,7 +15,12 @@ def create_district(name, slug, with_meeting: true, has_future_meeting: true, me
     total_police_paid_from_general_fund_budget: 420_000_000,
     decision_makers_text: "A budget proposal is made by the mayor, advised by the Budget Advisory Committee.\nSee below for elected offficals.",
     elected_officials_contact_link: "www.google.com"
+  }.merge(district_attrs)
+
+  district = PoliceDistrict.find_or_initialize_by(
+    slug: slug,
   )
+  district.update!(district_attributes)
   puts "District #{district.name}: Created or updated district with slug '#{district.slug}'"
   if with_meeting
     create_meeting(district, in_future: has_future_meeting, attr_overrides: meeting_attrs)
@@ -70,6 +72,7 @@ create_district("Los Angeles", "los-angeles")
 create_district("BART", "bart", has_future_meeting: false)
 create_district("San Mateo", "san-mateo", with_meeting: false)
 create_district("Richmond", "richmond", meeting_attrs: { how_to_comment: nil })
+create_district("Tucson", "tucson", district_attrs: { timezone: 'Arizona' })
 
 user = User.find_or_initialize_by(
   email: ENV.fetch('SEED_USER_EMAIL', 'admin@example.com')

--- a/spec/models/google_calendar_spec.rb
+++ b/spec/models/google_calendar_spec.rb
@@ -90,10 +90,4 @@ RSpec.describe GoogleCalendar do
       end
     end
   end
-
-  describe 'TIMEZONE_LOOKUP' do
-    it "has an entry for each valid PoliceDistrict timezone, so we don't leave any out accidentally" do
-      expect(GoogleCalendar::TIMEZONE_LOOKUP.keys).to match_array(PoliceDistrict::TIME_ZONE_OPTIONS)
-    end
-  end
 end

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Meeting, type: :model do
       travel_to DateTime.new(2009,10,20,13,30,00) do
         meeting = FactoryBot.build(:meeting, event_datetime: DateTime.new(2010,10,20,13,30,00))
         expect(meeting.formatted_event_datetime).to include('Wednesday, October 20 at ')
-        expect(meeting.formatted_event_datetime).to include('6:30am')
+        expect(meeting.formatted_event_datetime).to include('6:30am PDT')
       end
     end
 

--- a/spec/models/police_district_spec.rb
+++ b/spec/models/police_district_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe PoliceDistrict, type: :model do
 
       expect(FactoryBot.build(:police_district, timezone: 'Pacific Time (US & Canada)')).to be_valid
     end
+
+    it 'requires timezone default be a valid timezone' do
+      expect(FactoryBot.build(:police_district, timezone: PoliceDistrict::TIME_ZONE_DEFAULT)).to be_valid
+    end
   end
 
   describe 'setting .slug' do


### PR DESCRIPTION
This is the simplest approach--adds all valid US time zones (as
determined by Rails) to the dropdown when creating a district. Then
displays the timezone along with the time on all public-facing pages.

Google Calendar should support without any changes.

Would ideally set this off of the geocode, since the list is already
kind of overwhelming even though it's not comprehensive. I'm also not
sure how well it will deal with applying timezones from the string in
the database (e.g. for Arizona) when dealing across daylight savings changes.

[Closes #82]

<img width="851" alt="Screen Shot 2020-06-27 at 5 07 57 PM" src="https://user-images.githubusercontent.com/3675092/85934552-cbaeed00-b898-11ea-8ebb-d5fe0f8649ae.png">
<img width="917" alt="Screen Shot 2020-06-27 at 5 07 51 PM" src="https://user-images.githubusercontent.com/3675092/85934553-cce01a00-b898-11ea-8fec-0c636888b47f.png">
