### PR TITLE
Card datetime text fix

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -138,8 +138,10 @@ a.add-to-calendar-button, a.add-to-calendar-button:hover {
 .calendar-icon {
   background-image: url(assets/icons/ic_calendar.svg);
   height: 32px;
-  margin-right: 4px;
-  width: 32px;
+  margin-right: 8px;
+  width: 24px;
+  background-position: center;
+  background-size: 32px 32px;
 }
 
 .decision-makers-text {

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -213,7 +213,6 @@ a.add-to-calendar-button, a.add-to-calendar-button:hover {
     background-repeat: no-repeat;
     background-size: auto 100%;
     justify-content: flex-end;
-    width: 296px;
   }
 }
 
@@ -233,7 +232,7 @@ a.add-to-calendar-button, a.add-to-calendar-button:hover {
     align-items: flex-end;
     flex-direction: column;
     justify-content: center;
-    padding: 10px 32px 24px 32px;
+    padding: 10px 32px 24px 48px;
   }
 }
 

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -135,13 +135,16 @@ a.add-to-calendar-button, a.add-to-calendar-button:hover {
   }
 }
 
-.calendar-icon {
-  background-image: url(assets/icons/ic_calendar.svg);
+.row-icon {
   height: 32px;
   margin-right: 8px;
   width: 24px;
   background-position: center;
   background-size: 32px 32px;
+}
+
+.row-icon.calendar {
+  background-image: url(assets/icons/ic_calendar.svg);
 }
 
 .decision-makers-text {
@@ -174,6 +177,10 @@ a.add-to-calendar-button, a.add-to-calendar-button:hover {
   margin-top: 4px;
 }
 
+.district-card-datetime-text {
+  white-space: nowrap;
+}
+
 .past {
   opacity: 0.65;
 }
@@ -185,7 +192,7 @@ a.add-to-calendar-button, a.add-to-calendar-button:hover {
 
 @media(min-width: 569px) {
   .district-card-details-primary {
-    padding: 16px 32px 24px 32px;
+    padding: 16px 0 24px 32px;
   }
 }
 
@@ -206,7 +213,7 @@ a.add-to-calendar-button, a.add-to-calendar-button:hover {
     background-repeat: no-repeat;
     background-size: auto 100%;
     justify-content: flex-end;
-    width: 316px;
+    width: 296px;
   }
 }
 
@@ -755,18 +762,12 @@ a.add-to-calendar-button, a.add-to-calendar-button:hover {
   }
 }
 
-.check-icon {
+.row-icon.check {
   background-image: url(assets/icons/ic_past.svg);
-  height: 32px;
-  margin-right: 4px;
-  width: 32px;
 }
 
-.phone-icon {
+.row-icon.phone {
   background-image: url(assets/icons/ic_phone.svg);
-  height: 32px;
-  margin-right: 4px;
-  width: 32px;
 }
 
 .pie-chart {

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -13,12 +13,19 @@ class Meeting < ApplicationRecord
   }
 
   def formatted_event_datetime
-    if DateTime.now.in_time_zone(police_district.timezone).midnight == event_datetime&.in_time_zone(police_district.timezone).midnight
-      event_datetime&.in_time_zone(police_district.timezone)&.strftime('Today, %l:%M%P %Z')
-    elsif DateTime.now.in_time_zone(police_district.timezone).advance(:days => 6).midnight >= event_datetime&.in_time_zone(police_district.timezone).midnight
-      event_datetime&.in_time_zone(police_district.timezone)&.strftime('%A, %l:%M%P %Z')
+    if event_datetime == nil
+      nil
     else
-      event_datetime&.in_time_zone(police_district.timezone)&.strftime('%b %-m, %l:%M%P %Z')
+      day_diff = (event_datetime&.in_time_zone(police_district.timezone).midnight - DateTime.now.in_time_zone(police_district.timezone).midnight).to_i / 86400
+      time_format = '%l:%M%P %Z'
+
+      if day_diff == 0
+        event_datetime&.in_time_zone(police_district.timezone)&.strftime('Today, ' + time_format)
+      elsif day_diff >= 0 && day_diff <= 6
+        event_datetime&.in_time_zone(police_district.timezone)&.strftime('%A, ' + time_format)
+      else
+        event_datetime&.in_time_zone(police_district.timezone)&.strftime('%b %-d, ' + time_format)
+      end
     end
   end
 

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -13,7 +13,7 @@ class Meeting < ApplicationRecord
   }
 
   def formatted_event_datetime
-    event_datetime&.in_time_zone(police_district.timezone)&.strftime('%A, %B %e at %l:%M%P %Z')
+    event_datetime&.in_time_zone(police_district.timezone)&.strftime('%a, %-m/%d at %l:%M%P %Z')
   end
 
   def agenda_link_prefixed

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -13,7 +13,13 @@ class Meeting < ApplicationRecord
   }
 
   def formatted_event_datetime
-    event_datetime&.in_time_zone(police_district.timezone)&.strftime('%a, %-m/%d at %l:%M%P %Z')
+    if DateTime.now.in_time_zone(police_district.timezone).midnight == event_datetime&.in_time_zone(police_district.timezone).midnight
+      event_datetime&.in_time_zone(police_district.timezone)&.strftime('Today, %l:%M%P %Z')
+    elsif DateTime.now.in_time_zone(police_district.timezone).advance(:days => 6).midnight >= event_datetime&.in_time_zone(police_district.timezone).midnight
+      event_datetime&.in_time_zone(police_district.timezone)&.strftime('%A, %l:%M%P %Z')
+    else
+      event_datetime&.in_time_zone(police_district.timezone)&.strftime('%b %-m, %l:%M%P %Z')
+    end
   end
 
   def agenda_link_prefixed

--- a/app/views/shared/_district_card.html.erb
+++ b/app/views/shared/_district_card.html.erb
@@ -5,14 +5,14 @@
       <div>
         <% if next_meeting = district.next_meeting %>
           <div class="district-card-bullet">
-            <div class="calendar-icon"></div>
+            <div class="row-icon calendar"></div>
             <div class="district-card-datetime-text"><%= next_meeting.formatted_event_datetime %></div>
           </div>
           <!--TODO: Re-add bullet with correct comment method icon/description-->
         <% else %>
           <% if most_recent_meeting = district.most_recent_meeting %>
             <div class="district-card-bullet past">
-              <div class="check-icon"></div>
+              <div class="row-icon check"></div>
               <div class="district-card-datetime-text"><%= most_recent_meeting.formatted_event_datetime %></div>
             </div>
           <% end %>

--- a/app/views/shared/_district_card.html.erb
+++ b/app/views/shared/_district_card.html.erb
@@ -6,14 +6,14 @@
         <% if next_meeting = district.next_meeting %>
           <div class="district-card-bullet">
             <div class="calendar-icon"></div>
-            <div><%= next_meeting.formatted_event_datetime %></div>
+            <div class="district-card-datetime-text"><%= next_meeting.formatted_event_datetime %></div>
           </div>
           <!--TODO: Re-add bullet with correct comment method icon/description-->
         <% else %>
           <% if most_recent_meeting = district.most_recent_meeting %>
             <div class="district-card-bullet past">
               <div class="check-icon"></div>
-              <div><%= most_recent_meeting.formatted_event_datetime %></div>
+              <div class="district-card-datetime-text"><%= most_recent_meeting.formatted_event_datetime %></div>
             </div>
           <% end %>
         <% end %>

--- a/app/views/shared/_district_header.html.erb
+++ b/app/views/shared/_district_header.html.erb
@@ -12,14 +12,14 @@
         <% end %>
         <% if next_meeting = district.next_meeting %>
           <div class="district-card-bullet">
-            <div class="calendar-icon"></div>
+            <div class="row-icon calendar"></div>
             <div class="meeting-time"><%= next_meeting.formatted_event_datetime %></div>
           </div>
           <%= link_to "Add to calendar", google_calendar_link, class: "add-to-calendar-button" %>
         <% else %>
           <% if last_meeting = district.most_recent_meeting %>
             <div class="district-card-bullet past">
-              <div class="calendar-icon"></div>
+              <div class="row-icon calendar"></div>
               <div class="meeting-time"><%= last_meeting.formatted_event_datetime %></div>
             </div>
           <% else %>

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Meeting, type: :model do
     it 'returns the formatted string in the district timezone' do
       travel_to DateTime.new(2009,10,20,13,30,00) do
         meeting = FactoryBot.build(:meeting, event_datetime: DateTime.new(2010,10,20,13,30,00))
-        expect(meeting.formatted_event_datetime).to include('Wednesday, October 20 at ')
+        expect(meeting.formatted_event_datetime).to include('Oct 20,')
         expect(meeting.formatted_event_datetime).to include('6:30am PDT')
       end
     end

--- a/spec/system/admin/adds_information_spec.rb
+++ b/spec/system/admin/adds_information_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'information management' do
   end
 
   scenario 'adding meetings to an existing district' do
-    travel_to Date.parse('2020-06-03') do
+    travel_to Date.parse('2020-06-01') do
       login_as(user)
 
       visit admin_root_path
@@ -97,14 +97,14 @@ RSpec.describe 'information management' do
 
       click_on 'Create Meeting'
 
-      expect(page).to have_content('Wednesday, June 10 at 2:30am')
+      expect(page).to have_content('Jun 10, 2:30am')
 
       within('[data-spec=meetings]') { click_on 'Edit' }
 
       select '11 AM',  :from => "meeting_event_datetime_4i" #hour
       click_on 'Update Meeting'
 
-      expect(page).to have_content('Wednesday, June 10 at 11:30am')
+      expect(page).to have_content('Jun 10, 11:30am')
 
       visit '/d/berkeley'
 
@@ -119,7 +119,7 @@ RSpec.describe 'information management' do
   end
 
   scenario 'deleting a meeting', js: true do
-    travel_to Date.parse('2020-06-03') do
+    travel_to Date.parse('2020-06-01') do
       FactoryBot.create(:meeting,
                         police_district: district,
                         event_datetime: DateTime.new(2025,7,20,21,30,00, 0)) # 7/20/2020 @ 2:30pm Pacific)
@@ -131,11 +131,11 @@ RSpec.describe 'information management' do
       click_on 'Berkeley'
 
       within '[data-spec="meetings"]' do
-        expect(page).to have_content('Sunday, July 20 at 2:30pm PDT')
+        expect(page).to have_content('Jul 20, 2:30pm PDT')
 
         click_link 'Delete'
 
-        expect(page).not_to have_content('Sunday, July 20 at 2:30pm PDT')
+        expect(page).not_to have_content('Jul 20, 2:30pm PDT')
       end
     end
   end

--- a/spec/system/views_information_spec.rb
+++ b/spec/system/views_information_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'information viewing' do
       expect(page).to have_content('Upcoming meetings')
       expect(page).to have_content('Down town')
       expect(page).to have_content('$950M')
-      expect(page).to have_content('Friday, June 20 at 5:30am')
+      expect(page).to have_content('Jun 20, 5:30am')
     end
 
     click_on 'Down town'
@@ -47,7 +47,7 @@ RSpec.describe 'information viewing' do
     expect(page).to have_content('Down town')
     expect(page).to have_content('$950M')
     expect(page).to have_content('Upcoming meeting')
-    expect(page).to have_content('Friday, June 20 at 5:30am')
+    expect(page).to have_content('Jun 20, 5:30am')
     expect(page).to have_content('Some people decide on these things')
     expect(page).to have_link('Add to calendar')
     expect(page).to_not have_content('This meeting has ended.')
@@ -60,7 +60,7 @@ RSpec.describe 'information viewing' do
       expect(page).to have_content('Recent meetings')
       expect(page).to have_content('Stu Ville')
       expect(page).to have_content('$10M')
-      expect(page).to have_content('Wednesday, June 30 at 11:30am')
+      expect(page).to have_content('Jun 30, 11:30am')
     end
 
     click_on 'Stu Ville'
@@ -68,7 +68,6 @@ RSpec.describe 'information viewing' do
     expect(page).to have_content('Stu Ville')
     expect(page).to have_content('$10M')
     expect(page).to have_content('Last meeting')
-    expect(page).to have_content('Wednesday, June 30 at 11:30am')
     expect(page).to_not have_link('Add to calendar')
     expect(page).to have_content('This meeting has ended.')
     expect(page).to have_content('An archive of the meeting page\'s contents is shown below.')


### PR DESCRIPTION
Fixes a visual issue where the text was getting too long and wrapping in some funky ways.

<img width="555" alt="Screen Shot 2020-06-28 at 11 24 51 PM" src="https://user-images.githubusercontent.com/550991/85983701-d0f56000-b99c-11ea-8ae0-b3de0c9b6566.png">
