### PR TITLE
Add ability to update the page slug

### DIFF
--- a/app/controllers/admin/police_districts_controller.rb
+++ b/app/controllers/admin/police_districts_controller.rb
@@ -46,6 +46,7 @@ class Admin::PoliceDistrictsController < Admin::ApplicationController
   def district_params
     params.require(:police_district).permit(
       :name,
+      :slug,
       :total_district_budget,
       :total_police_department_budget,
       :total_general_fund_budget,

--- a/app/models/police_district.rb
+++ b/app/models/police_district.rb
@@ -75,6 +75,6 @@ class PoliceDistrict < ApplicationRecord
   private
 
   def set_slug
-    self.slug = (slug || name.to_s.parameterize)
+    self.slug = slug.present? ? slug : name.to_s.parameterize
   end
 end

--- a/app/views/admin/police_districts/_district_form.html.erb
+++ b/app/views/admin/police_districts/_district_form.html.erb
@@ -7,6 +7,13 @@
         <%= f.text_field :name, class: 'form-control' %>
       </div>
 
+      <% if @district.slug.present? %>
+        <div class="form-group form-group--medium">
+          <%= f.label :slug %>
+          <%= f.text_field :slug, class: 'form-control' %>
+        </div>
+      <% end %>
+
       <div class="form-group form-group--medium">
         <%= f.label :address %>
         <%= f.text_field :address, class: 'form-control' %>

--- a/spec/models/police_district_spec.rb
+++ b/spec/models/police_district_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe PoliceDistrict, type: :model do
   end
 
   describe 'setting .slug' do
+    it 'does not update if slug is an empty string' do
+      district = FactoryBot.create(:police_district, name: 'Police Department')
+      district.update(slug: '')
+
+      expect(district.slug).to eq('police-department')
+    end
+
     context 'when model is invalid' do
       it 'does not set slug on the item' do
         district = FactoryBot.build(:police_district, name: nil, slug: nil)

--- a/spec/system/admin/adds_information_spec.rb
+++ b/spec/system/admin/adds_information_spec.rb
@@ -67,9 +67,10 @@ RSpec.describe 'information management' do
 
     click_on 'Edit'
     fill_in 'Name', with: "New District Name"
+    fill_in 'Slug', with: 'berkeley-1'
     click_on 'Update Police district'
 
-    visit '/d/berkeley'
+    visit '/d/berkeley-1'
     expect(page).to have_content('New District Name')
   end
 


### PR DESCRIPTION
Only show field when updating a district (we still want to auto-generate
the slug when creating new distrits--this is mainly for if we make a
typo or something in the name).

Closes #81 