### PR TITLE
Raise error so 404 is triggered when URL is wrong

### DIFF
--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -55,7 +55,7 @@ class Admin::MeetingsController < Admin::ApplicationController
   attr_reader :district
 
   def set_police_district
-    @district = PoliceDistrict.find_by_slug(params[:police_district_id])
+    @district = PoliceDistrict.find_by_slug!(params[:police_district_id])
   end
 
   def meeting_params

--- a/app/controllers/admin/police_districts_controller.rb
+++ b/app/controllers/admin/police_districts_controller.rb
@@ -1,6 +1,8 @@
 class Admin::PoliceDistrictsController < Admin::ApplicationController
   include GoogleCalendarable
 
+  before_action :set_district, except: [:new, :create, :index]
+
   def new
     @district = PoliceDistrict.new
 
@@ -19,17 +21,14 @@ class Admin::PoliceDistrictsController < Admin::ApplicationController
   end
 
   def show
-    @district = PoliceDistrict.find_by_slug(params[:id])
+    render :show
   end
 
   def edit
-    @district = PoliceDistrict.find_by_slug(params[:id])
-
     render :edit
   end
 
   def update
-    @district = PoliceDistrict.find_by_slug(params[:id])
     if @district.update(district_params)
       redirect_to admin_police_districts_path
     else
@@ -42,6 +41,10 @@ class Admin::PoliceDistrictsController < Admin::ApplicationController
   end
 
   private
+
+  def set_district
+    @district = PoliceDistrict.find_by_slug!(params[:id])
+  end
 
   def district_params
     params.require(:police_district).permit(

--- a/app/controllers/police_districts_controller.rb
+++ b/app/controllers/police_districts_controller.rb
@@ -7,7 +7,7 @@ class PoliceDistrictsController < ApplicationController
   end
 
   def show
-    @district = PoliceDistrict.find_by_slug(params[:slug])
+    @district = PoliceDistrict.find_by_slug!(params[:slug])
     @meeting = @district.next_meeting.present? ? @district.next_meeting : @district.most_recent_meeting
   end
 end

--- a/spec/controllers/admin/meetings_controller_spec.rb
+++ b/spec/controllers/admin/meetings_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::MeetingsController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   let!(:district) { FactoryBot.create(:police_district, slug: 'oakland', timezone: 'Pacific Time (US & Canada)') }
+  let!(:meeting) { FactoryBot.create(:meeting, police_district: district, event_datetime: DateTime.new(2025,1,20,11,0,0,0)) }
 
   context 'when user is signed in' do
     before do
@@ -63,6 +64,12 @@ RSpec.describe Admin::MeetingsController, type: :controller do
         }
       end
 
+      it 'returns 404 if district not present' do
+        expect do
+          post :update, params: { police_district_id: 'asldkfjaslkfdj', id: meeting.id }
+        end.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+
       it 'converts datetime from district timezone to UTC before storing' do
         travel_to Date.parse('2020-06-03') do
           expect do
@@ -73,9 +80,13 @@ RSpec.describe Admin::MeetingsController, type: :controller do
     end
 
     describe '#edit' do
-      let!(:meeting) { FactoryBot.create(:meeting, police_district: district, event_datetime: DateTime.new(2025,1,20,11,0,0,0)) }
-
       render_views
+
+      it 'returns 404 if district not present' do
+        expect do
+          post :edit, params: { police_district_id: 'asldkfjaslkfdj', id: meeting.id }
+        end.to raise_exception(ActiveRecord::RecordNotFound)
+      end
 
       it 'converts time to district timezone, but strips timezone' do
         travel_to Date.parse('2020-06-03') do
@@ -87,9 +98,13 @@ RSpec.describe Admin::MeetingsController, type: :controller do
     end
 
     describe '#destroy' do
-      let!(:meeting) { FactoryBot.create(:meeting, police_district: district) }
-
       context 'js request' do
+        it 'returns 404 if district not present' do
+          expect do
+            post :update, format: :js, params: { police_district_id: 'asldkfjaslkfdj', id: meeting.id }
+          end.to raise_exception(ActiveRecord::RecordNotFound)
+        end
+
         it 'deletes the meeting' do
           expect do
             delete :destroy, format: :js, params: { police_district_id: district.slug, id: meeting.id }

--- a/spec/controllers/admin/police_districts_controller_spec.rb
+++ b/spec/controllers/admin/police_districts_controller_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Admin::PoliceDistrictsController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  let!(:district) { FactoryBot.create(:police_district, slug: 'oakland', timezone: 'Pacific Time (US & Canada)') }
+
+  context 'when user is signed in' do
+    before do
+      sign_in user
+    end
+
+    describe '#update' do
+      it 'returns 404 if district not present' do
+        expect do
+          post :update, params: { id: 'asldkfjaslkfdj' }
+        end.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe '#edit' do
+      render_views
+
+      it 'returns 404 if district not present' do
+        expect do
+          post :edit, params: { id: 'asldkfjaslkfdj' }
+        end.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe '#destroy' do
+      it 'returns 404 if district not present' do
+        expect do
+          post :update, params: { id: 'asldkfjaslkfdj' }
+        end.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe '#show' do
+      it 'returns 404 if district not present' do
+        expect do
+          get :show, params: { id: 'asldkfjaslkfdj' }
+        end.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/controllers/police_districts_controller_spec.rb
+++ b/spec/controllers/police_districts_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe PoliceDistrictsController, type: :controller do
+  describe '#show' do
+    it 'returns 404 if district not present' do
+      expect do
+        get :show, params: { slug: 'asldkfjaslkfdj' }
+      end.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
Record.find_by_x doesn't raise an ActiveRecord::RecordNotFound error,
which triggers the 404, so our app was returning a 500 error when
incorrect district URLs were accessed. (e.g. /d/san-francisco-sdf). This
should protect against that (but only in hosted environments)

We could still use a nice 404 page—right now we use the Rails default.

#80 